### PR TITLE
More prometheus metrics for filtering documents

### DIFF
--- a/python/batcher.py
+++ b/python/batcher.py
@@ -49,10 +49,10 @@ def publish_batch(
 
 def process_document(metadata: Any, counters: Mapping[str, Counter]) -> bool:
     counters['total_docs'].inc()
-    if not "languages" in metadata and "eng" in metadata["languages"]:
+    if "languages" not in metadata or "eng" not in metadata["languages"]:
         counters['non_english'].inc()
         return False
-    if not metadata.get("status") == "200":
+    if metadata.get("status") != "200":
         counters['non_200'].inc()
         return False
     counters['passed_filter'].inc()

--- a/python/worker.py
+++ b/python/worker.py
@@ -9,9 +9,11 @@ from commoncrawl import BASE_URL, CCDownloader, Downloader
 from rabbitmq import QUEUE_NAME, rabbitmq_channel
 
 
-batch_counter = Counter("worker_batches", "Number of consumed batches")
-invalid_record_counter = Counter("worker_invalid_records", "Number of invalid records")
-total_records_counter = Counter("worker_total_records", "Total number of records")
+counters = {
+    "batches": Counter("worker_batches", "Number of consumed batches"),
+    "invalid_records": Counter("worker_invalid_records", "Number of invalid records"),
+    "total_records": Counter("worker_total_records", "Total number of records"),
+}
 
 
 def process_batch(downloader: Downloader, ch, method, _properties, body):
@@ -28,9 +30,9 @@ def process_batch(downloader: Downloader, ch, method, _properties, body):
                 _text = trafilatura.extract(record.content_stream().read())
                 # TODO: process text
             else:
-                invalid_record_counter.inc()
-            total_records_counter.inc()
-    batch_counter.inc()
+                counters["invalid_records"].inc()
+            counters["total_records"].inc()
+    counters["batches"].inc()
     ch.basic_ack(delivery_tag=method.delivery_tag)
 
 

--- a/python/worker.py
+++ b/python/worker.py
@@ -10,8 +10,8 @@ from rabbitmq import QUEUE_NAME, rabbitmq_channel
 
 
 batch_counter = Counter("worker_batches", "Number of consumed batches")
-valid_record_counter = Counter("worker_valid_records", "Number of valid records")
-total_records_counter = Counter("total_records", "Total number of records")
+invalid_record_counter = Counter("worker_invalid_records", "Number of invalid records")
+total_records_counter = Counter("worker_total_records", "Total number of records")
 
 
 def process_batch(downloader: Downloader, ch, method, _properties, body):
@@ -26,8 +26,9 @@ def process_batch(downloader: Downloader, ch, method, _properties, body):
         for record in WARCIterator(io.BytesIO(data)):
             if record.rec_type == "response":
                 _text = trafilatura.extract(record.content_stream().read())
-                valid_record_counter.inc()
                 # TODO: process text
+            else:
+                invalid_record_counter.inc()
             total_records_counter.inc()
     batch_counter.inc()
     ch.basic_ack(delivery_tag=method.delivery_tag)

--- a/python/worker.py
+++ b/python/worker.py
@@ -10,6 +10,8 @@ from rabbitmq import QUEUE_NAME, rabbitmq_channel
 
 
 batch_counter = Counter("worker_batches", "Number of consumed batches")
+valid_record_counter = Counter("worker_valid_records", "Number of valid records")
+total_records_counter = Counter("total_records", "Total number of records")
 
 
 def process_batch(downloader: Downloader, ch, method, _properties, body):
@@ -24,7 +26,9 @@ def process_batch(downloader: Downloader, ch, method, _properties, body):
         for record in WARCIterator(io.BytesIO(data)):
             if record.rec_type == "response":
                 _text = trafilatura.extract(record.content_stream().read())
+                valid_record_counter.inc()
                 # TODO: process text
+            total_records_counter.inc()
     batch_counter.inc()
     ch.basic_ack(delivery_tag=method.delivery_tag)
 

--- a/python/worker.py
+++ b/python/worker.py
@@ -9,7 +9,7 @@ from commoncrawl import BASE_URL, CCDownloader, Downloader
 from rabbitmq import QUEUE_NAME, rabbitmq_channel
 
 
-counters = {
+COUNTERS = {
     "batches": Counter("worker_batches", "Number of consumed batches"),
     "invalid_records": Counter("worker_invalid_records", "Number of invalid records"),
     "total_records": Counter("worker_total_records", "Total number of records"),
@@ -30,9 +30,9 @@ def process_batch(downloader: Downloader, ch, method, _properties, body):
                 _text = trafilatura.extract(record.content_stream().read())
                 # TODO: process text
             else:
-                counters["invalid_records"].inc()
-            counters["total_records"].inc()
-    counters["batches"].inc()
+                COUNTERS["invalid_records"].inc()
+            COUNTERS["total_records"].inc()
+    COUNTERS["batches"].inc()
     ch.basic_ack(delivery_tag=method.delivery_tag)
 
 


### PR DESCRIPTION
Counters added for batcher:

batcher_total_documents: Total documents processed by the batcher
batcher_non_english_documents: Documents filtered out for not being English
batcher_non_200_documents: Documents filtered out for not having status 200
batcher_passed_filter_documents: Documents that passed all filters
Counters added for worker:

worker_invalid_records: Number of invalid records
worker_total_records: Total number of records